### PR TITLE
:egg::egg: Using port 1919 of host, because 80 was busy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,4 +66,4 @@ destroy:
 
 # Curls
 curl_measure:
-	curl -v -X POST -H "Content-Type: application/json" http://localhost/measure  -d '{"temperature": 31.2, "humidity": 41.6}'
+	curl -v -X POST -H "Content-Type: application/json" http://localhost:1919/measure  -d '{"temperature": 31.2, "humidity": 41.6}'

--- a/deploy/cluster-config.yaml
+++ b/deploy/cluster-config.yaml
@@ -10,7 +10,7 @@ nodes:
             node-labels: "ingress-ready=true"
     extraPortMappings:
       - containerPort: 80
-        hostPort: 80
+        hostPort: 1919
         protocol: TCP
       - containerPort: 443
         hostPort: 443


### PR DESCRIPTION
I haven't tried @dotdc's solution, but I think using :80 is a bit extreme. I switched to a "random" other port, and got this result :
```bash
▶ make curl_measure 
curl -v -X POST -H "Content-Type: application/json" http://localhost:1919/measure  -d '{"temperature": 31.2, "humidity": 41.6}'
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:1919...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 1919 (#0)
> POST /measure HTTP/1.1
> Host: localhost:1919
> User-Agent: curl/7.68.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 39
> 
* upload completely sent off: 39 out of 39 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 201 Created
< Date: Sat, 23 Jul 2022 17:32:41 GMT
< Content-Length: 0
< Connection: keep-alive
< 
* Connection #0 to host localhost left intact
```